### PR TITLE
Avoid mutating scenes array when rendering draft

### DIFF
--- a/src/components/FormattedDraft.tsx
+++ b/src/components/FormattedDraft.tsx
@@ -67,8 +67,8 @@ export default function FormattedDraft({ screenplay }: Props) {
   return (
     <div className="script-sheet">
       <div className="script-content">
-        {(screenplay.scenes || [])
-          .sort((a,b)=>a.number-b.number)
+        {[...(screenplay.scenes || [])]
+          .sort((a, b) => a.number - b.number)
           .map((sc) => (
             <div key={sc.id}>
               <div className="scene-heading">{sc.slugline || 'INT./EXT. TBD - DAY'}</div>


### PR DESCRIPTION
## Summary
- Copy `screenplay.scenes` before sorting in `FormattedDraft` to prevent state mutation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `node -e "const arr=[{number:2},{number:1}]; const sorted=[...(arr||[])].sort((a,b)=>a.number-b.number); console.log('original', arr.map(x=>x.number)); console.log('sorted', sorted.map(x=>x.number));"`


------
https://chatgpt.com/codex/tasks/task_e_689cc6aae5e883329229a9e6391ed65d