### PR TITLE
feat: enrich scene typing

### DIFF
--- a/src/components/FormattedDraft.tsx
+++ b/src/components/FormattedDraft.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '../styles/hollywood.css';
-import type { Screenplay } from '../types';
+import type { Screenplay, Scene } from '../types';
 
 type Props = { screenplay: Screenplay };
 
@@ -64,10 +64,11 @@ function parseSynopsisToBlocks(s: string): El[] {
 
 export default function FormattedDraft({ screenplay }: Props) {
   // (Paginación real vendrá después; ahora es una única “sheet” larga)
+  const scenes = (screenplay.scenes || []) as Scene[];
   return (
     <div className="script-sheet">
       <div className="script-content">
-        {(screenplay.scenes || [])
+        {scenes
           .sort((a,b)=>a.number-b.number)
           .map((sc) => (
             <div key={sc.id}>

--- a/src/pages/StoryMachine/editors/S6LocationEditor.tsx
+++ b/src/pages/StoryMachine/editors/S6LocationEditor.tsx
@@ -120,7 +120,8 @@ export default function S6LocationsEditor() {
       const key = (s.locationName || '').trim();
       if (!key) return;
       const arr = map.get(key) ?? [];
-      arr.push(idx + 1); // nº de escena = índice + 1
+      const num = s.number || idx + 1; // nº de escena = índice + 1 por defecto
+      arr.push(num);
       map.set(key, arr);
     });
     return map;
@@ -130,6 +131,11 @@ export default function S6LocationsEditor() {
   const createSceneAt = (locationName: string) => {
     const newScene: Scene = {
       id: crypto.randomUUID(),
+      number: (screenplay?.scenes?.length ?? 0) + 1,
+      slugline: '',
+      characters: [],
+      synopsis: '',
+      isKey: false,
       locationName: locationName.trim(),
       placeType: 'INT',
       timeOfDay: 'DAY',
@@ -138,7 +144,7 @@ export default function S6LocationsEditor() {
       purpose: '',
       subplotId: null,
       characterIds: []
-    } as Scene;
+    };
     patch({ scenes: [ ...(screenplay?.scenes ?? []), newScene ] });
   };
 

--- a/src/pages/StoryMachine/editors/S7AllScenesEditor.tsx
+++ b/src/pages/StoryMachine/editors/S7AllScenesEditor.tsx
@@ -31,6 +31,11 @@ import type {
 function createEmptyScene(): Scene {
   return {
     id: crypto.randomUUID(),
+    number: 0,
+    slugline: '',
+    characters: [],
+    synopsis: '',
+    isKey: false,
     locationName: '',
     placeType: 'INT',
     timeOfDay: 'DAY',
@@ -123,9 +128,14 @@ export default function S7AllScenesEditor() {
   useEffect(() => {
     const raw = (screenplay?.scenes ?? []) as any[];
     let changed = false;
-    const sanitized = raw.map((s) => {
+    const sanitized = raw.map((s, i) => {
       const fixed: Scene = {
         id: s.id ?? crypto.randomUUID(),
+        number: typeof s.number === 'number' ? s.number : i + 1,
+        slugline: s.slugline ?? '',
+        characters: Array.isArray(s.characters) ? s.characters : [],
+        synopsis: s.synopsis ?? '',
+        isKey: !!s.isKey,
         locationName: s.locationName ?? '',
         placeType: (s.placeType ?? 'INT') as ScenePlaceType,
         timeOfDay: (s.timeOfDay ?? 'DAY') as TimeOfDay,
@@ -139,7 +149,12 @@ export default function S7AllScenesEditor() {
         fixed.locationName !== s.locationName ||
         fixed.placeType !== s.placeType ||
         fixed.timeOfDay !== s.timeOfDay ||
-        (Array.isArray(s.characterIds) ? false : true)
+        (Array.isArray(s.characterIds) ? false : true) ||
+        typeof s.number !== 'number' ||
+        fixed.slugline !== s.slugline ||
+        (Array.isArray(s.characters) ? false : true) ||
+        fixed.synopsis !== s.synopsis ||
+        (!!s.isKey) !== fixed.isKey
       ) changed = true;
       return fixed;
     });

--- a/src/pages/StoryMachine/editors/guards.ts
+++ b/src/pages/StoryMachine/editors/guards.ts
@@ -1,4 +1,4 @@
-import type { Screenplay, TurningPointType, IdeaRow, UniversalTheme } from '../../../types';
+import type { Screenplay, TurningPointType, IdeaRow, UniversalTheme, Scene } from '../../../types';
 
 export const hasMinSynopsis = (synopsis?: string) => (synopsis?.trim().split(/\s+/).length || 0) >= 120;
 
@@ -21,7 +21,7 @@ export const hasProtagonist = (chars?: { name: string; isProtagonist?: boolean }
 export const hasLinkedSubplots = (subs?: { name: string; ownerId?: string }[]) =>
   (subs||[]).every(s => s.name.trim() && s.ownerId);
 
-export const hasMinKeyScenes = (scenes?: { isKey?: boolean }[]) =>
+export const hasMinKeyScenes = (scenes?: Scene[]) =>
   (scenes||[]).filter(s => s.isKey).length >= 5;
 
 export const hasAllScenes = (scenes?: unknown[]) => (scenes||[]).length >= 30; // mock

--- a/src/state/screenplayStore.ts
+++ b/src/state/screenplayStore.ts
@@ -29,15 +29,23 @@ export const useScreenplay = create<SPState>((set, get) => ({
     const sp = get().screenplay!;
     const scenes = [...(sp.scenes||[])];
     const idx = scenes.findIndex(s => s.id === scene.id);
-    const merged = {
+    const merged: Scene = {
       id: scene.id || crypto.randomUUID(),
       number: scene.number ?? scenes.length + 1,
       slugline: scene.slugline || 'INT. TBD - DAY',
       characters: scene.characters || [],
       synopsis: scene.synopsis || '',
-      isKey: !!scene.isKey
+      isKey: !!scene.isKey,
+      locationName: scene.locationName || '',
+      placeType: scene.placeType || 'INT',
+      timeOfDay: scene.timeOfDay || 'DAY',
+      plotPoint: scene.plotPoint,
+      description: scene.description || '',
+      purpose: scene.purpose || '',
+      subplotId: scene.subplotId ?? null,
+      characterIds: scene.characterIds || []
     };
-    if (idx >= 0) scenes[idx] = { ...scenes[idx], ...merged }; else scenes.push(merged as any);
+    if (idx >= 0) scenes[idx] = { ...scenes[idx], ...merged }; else scenes.push(merged);
     const next = { ...sp, scenes };
     mockScreenplays.update(next); set({ screenplay: next });
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,16 @@ export type ConflictLevel = 'Extrapersonal' | 'Personal' | 'Interno';
 
 export type Scene = {
   id: string;
+  /** Número de escena dentro del guion */
+  number: number;
+  /** Encabezado de la escena en formato slugline */
+  slugline: string;
+  /** Personajes mencionados en la escena (nombres libres) */
+  characters: string[];
+  /** Sinopsis o contenido en formato texto simple */
+  synopsis: string;
+  /** Marca si la escena es clave dentro de la historia */
+  isKey?: boolean;
   locationName: string;        // guardamos el texto (índice por nombre)
   placeType: ScenePlaceType;   // INT / EXT / NA
   timeOfDay: TimeOfDay;        // DAY / NIGHT / OTHER


### PR DESCRIPTION
## Summary
- expand `Scene` with screenplay properties like number, slugline, characters, synopsis and key flag
- align store and editors to create and sanitize scenes with the new fields
- typecheck passes

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cc6917ae88332a036269f7ac7b0b4