### PR TITLE
fix: avoid pre-mount state update in StoryDraftView

### DIFF
--- a/src/pages/StoryDraft/StoryDraftView.tsx
+++ b/src/pages/StoryDraft/StoryDraftView.tsx
@@ -306,7 +306,6 @@ function SceneEditorRow({
     autofocus: false,
     onCreate: ({ editor }) => {
       annotateAllParagraphTypes(editor);
-      setActiveType(getCurrentParagraphType(editor));
     },
     onUpdate: ({ editor }) => {
       annotateAllParagraphTypes(editor);
@@ -316,6 +315,12 @@ function SceneEditorRow({
       setActiveType(getCurrentParagraphType(editor));
     }
   }, [initialHtml]);
+
+  useEffect(() => {
+    if (editor) {
+      setActiveType(getCurrentParagraphType(editor));
+    }
+  }, [editor]);
 
   const scheduleSave = useRef<null | (() => void)>(null);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid React state update before component mount in StoryDraftView

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ccad89c8083329509a450214024fa