### PR TITLE
fix: clean up TypeScript warnings

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import {
-  AppBar, Toolbar, Typography, Box, IconButton, Tooltip, Button, TextField, MenuItem, FormControl, Select
+  AppBar, Toolbar, Typography, Box, IconButton, Tooltip, MenuItem, FormControl, Select
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import LightModeIcon from '@mui/icons-material/LightMode';

--- a/src/pages/StoryDraft/StoryDraftView.tsx
+++ b/src/pages/StoryDraft/StoryDraftView.tsx
@@ -18,6 +18,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Placeholder from '@tiptap/extension-placeholder';
 import Paragraph from '@tiptap/extension-paragraph';
+import type { CommandProps } from '@tiptap/core';
 
 import { useNavigate } from 'react-router-dom';
 import { useProjects } from '../../state/projectStore';
@@ -119,7 +120,7 @@ function getCurrentParagraphType(editor: any): BlockType {
 }
 function setCurrentParagraphType(editor: any, type: BlockType) {
   const pos = getCurrentParagraphPos(editor);
-  editor.commands.command(({ tr, state, dispatch }) => {
+  editor.commands.command(({ tr, state, dispatch }: CommandProps) => {
     const node = state.doc.nodeAt(pos);
     if (node && node.type.name === 'paragraph') {
       tr.setNodeMarkup(pos, node.type, { ...(node.attrs || {}), 'data-type': type });
@@ -134,7 +135,7 @@ function replaceCurrentLine(editor: any, newText: string, setType?: BlockType) {
   const { $from } = state.selection;
   const from = $from.start();
   const to = $from.end();
-  editor.commands.command(({ tr, dispatch }) => {
+  editor.commands.command(({ tr, dispatch }: CommandProps) => {
     tr.insertText(newText, from, to);
     if (dispatch) dispatch(tr);
     return true;
@@ -158,7 +159,7 @@ function cycleType(editor: any, dir: 1 | -1) {
   else setCurrentParagraphType(editor, next);
 }
 function annotateAllParagraphTypes(editor: any) {
-  editor.commands.command(({ tr, state, dispatch }) => {
+  editor.commands.command(({ tr, state, dispatch }: CommandProps) => {
     let lastType: BlockType | undefined;
     state.doc.descendants((node: any, pos: number) => {
       if (node.type?.name === 'paragraph') {
@@ -208,7 +209,6 @@ function ensureCharactersFromBlocks(blocks: ScriptBlock[], existing: Character[]
 /* ─────────────── Vista principal ─────────────── */
 
 export default function StoryDraftView() {
-  const t = useT();
   const navigate = useNavigate();
   const { activeProjectId } = useProjects();
   const { screenplay, load, patch } = useScreenplay();

--- a/src/pages/StoryMachine/StoryMachineShell.tsx
+++ b/src/pages/StoryMachine/StoryMachineShell.tsx
@@ -6,7 +6,7 @@ import { useScreenplay } from '../../state/screenplayStore';
 
 export default function StoryMachineShell() {
   const { activeProjectId } = useProjects();
-  const { screenplay, load, setTitle, upsertScene } = useScreenplay();
+  const { screenplay, load, setTitle } = useScreenplay();
 
   useEffect(() => { if (activeProjectId) load(activeProjectId); }, [activeProjectId]);
 

--- a/src/pages/StoryMachine/StoryMachineView.tsx
+++ b/src/pages/StoryMachine/StoryMachineView.tsx
@@ -1,5 +1,4 @@
-import { Box, Paper, Tabs, Tab, Button, Typography, TextField, Chip } from '@mui/material';
-import Grid from '@mui/material/Grid';
+import { Box, Paper, Tabs, Tab, Typography, TextField } from '@mui/material';
 import { useState, useEffect } from 'react';
 import { useProjects } from '../../state/projectStore';
 import { useScreenplay } from '../../state/screenplayStore';
@@ -17,7 +16,7 @@ const STEPS = ['S1 Sinopsis','S3 Puntos giro','S2 Tratamiento','S4 Personajes','
 export default function StoryMachineView() {
   const [tab, setTab] = useState(0);
   const { activeProjectId } = useProjects();
-  const { screenplay, load, setTitle, upsertScene } = useScreenplay();
+  const { screenplay, load, setTitle } = useScreenplay();
 
   useEffect(() => { if (activeProjectId) load(activeProjectId); }, [activeProjectId]);
 

--- a/src/pages/StoryMachine/editors/S2TreatmentEditor.tsx
+++ b/src/pages/StoryMachine/editors/S2TreatmentEditor.tsx
@@ -72,8 +72,8 @@ export default function S2TreatmentEditor() {
 
   // Cargar contenido inicial: si hay HTML lo usamos; si solo hay MD, lo convertimos a HTML
   const initialHtml = useMemo(() => {
-    const html = (screenplay as any)?.treatmentHtml as string | undefined;
-    const md = (screenplay as any)?.treatmentMd as string | undefined;
+    const html = screenplay?.treatmentHtml;
+    const md = screenplay?.treatmentMd;
     if (html && html.trim()) return html;
     if (md && md.trim()) return marked.parse(md);
     return '';

--- a/src/pages/StoryMachine/editors/S4CharactersEditor.tsx
+++ b/src/pages/StoryMachine/editors/S4CharactersEditor.tsx
@@ -16,7 +16,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 
 import { useScreenplay } from '../../../state/screenplayStore';
-import type { Character, CharacterRelation, ConflictLevel } from '../../../types';
+import type { Character, ConflictLevel } from '../../../types';
 import { ARCHETYPES } from '../../../data/archetypes';
 import { TRAIT_SUGGESTIONS } from '../../../data/traits';
 import { useT, useTx } from '../../../i18n';
@@ -200,7 +200,6 @@ export default function S4CharactersEditor() {
             <Grid key={c.id} size={{ xs: 12, md: 6, lg: 6 }}>
               <CompactCharacterCard
                 c={c}
-                all={characters}
                 t={t}
                 onEdit={() => setEditing(c)}
                 onDelete={() => removeCharacter(c.id)}
@@ -272,16 +271,16 @@ export default function S4CharactersEditor() {
 
 /* ───────────────── Card compacta (se mantiene) ───────────────── */
 
-function CompactCharacterCard({
-  c, all, t,
-  onEdit, onDelete,
-  onOpenBio, onOpenRelations
-}: {
-  c: Character; all: Character[]; t: (k:string)=>string;
-  onEdit: () => void; onDelete: () => void;
-  onOpenBio: (anchor: HTMLElement) => void;
-  onOpenRelations: (anchor: HTMLElement) => void;
-}) {
+  function CompactCharacterCard({
+    c, t,
+    onEdit, onDelete,
+    onOpenBio, onOpenRelations
+  }: {
+    c: Character; t: (k:string)=>string;
+    onEdit: () => void; onDelete: () => void;
+    onOpenBio: (anchor: HTMLElement) => void;
+    onOpenRelations: (anchor: HTMLElement) => void;
+  }) {
   const arch = c.archetypes || [];
   const nature = summarizeInline(c.nature, 3);
   const attitude = summarizeInline(c.attitude, 3);
@@ -457,17 +456,6 @@ function EditCharacterDialog({ open, value, allCharacters, onCancel, onSave }: E
 
   const otherCharacters = allCharacters.filter(c => c.id !== draft.id);
   const canRelate = otherCharacters.length > 0;
-  const addRelation = () => {
-    if (!canRelate) return;
-    const first = otherCharacters[0]?.id;
-    set({ relations: [...(draft.relations ?? []), { id: crypto.randomUUID(), targetId: first, description: '' }] });
-  };
-  const updateRelation = (id: string, patch: Partial<CharacterRelation>) => {
-    set({ relations: (draft.relations ?? []).map(r => r.id === id ? { ...r, ...patch } : r) });
-  };
-  const removeRelation = (id: string) => {
-    set({ relations: (draft.relations ?? []).filter(r => r.id !== id) });
-  };
 
   return (
     <Dialog open={open} onClose={onCancel} maxWidth="md" fullWidth>

--- a/src/pages/StoryMachine/editors/S7AllScenesEditor.tsx
+++ b/src/pages/StoryMachine/editors/S7AllScenesEditor.tsx
@@ -21,7 +21,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 
 import { useScreenplay } from '../../../state/screenplayStore';
-import { useT } from '../../../i18n';
+import { useT, useTx } from '../../../i18n';
 import type {
   Scene, ScenePlaceType, TimeOfDay, PlotPointKey, Character, Location, Subplot
 } from '../../../types';
@@ -122,6 +122,7 @@ function ppLabel(t: ReturnType<typeof useT>, value?: PlotPointKey) {
 
 export default function S7AllScenesEditor() {
   const t = useT();
+  const tx = useTx();
   const { screenplay, patch } = useScreenplay();
 
   // Sanitiza escenas antiguas
@@ -211,8 +212,6 @@ export default function S7AllScenesEditor() {
   };
 
   const addScene = () => patch({ scenes: [...scenes, createEmptyScene()] });
-  const updateScene = (id: string, s: Scene) =>
-    patch({ scenes: (screenplay?.scenes ?? []).map(x => x.id === id ? s : x) });
   const removeScene = (id: string) =>
     patch({ scenes: (screenplay?.scenes ?? []).filter(x => x.id !== id) });
 
@@ -263,10 +262,10 @@ export default function S7AllScenesEditor() {
         />
         {q && (
           <Typography variant="caption" sx={{ opacity:.7 }}>
-            {q && (filtered.length === 1
-              ? t('s7.search.one')
-              : t('s7.search.many', { n: String(filtered.length) })
-            )}
+              {q && (filtered.length === 1
+                ? t('s7.search.one')
+                : tx('s7.search.many', { n: String(filtered.length) })
+              )}
           </Typography>
         )}
       </Stack>

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,8 +48,10 @@ export type Screenplay = {
   id: string; 
   title: string; 
   projectId: string;
-  synopsis?: string; 
+  synopsis?: string;
   treatment?: string;
+  treatmentMd?: string;
+  treatmentHtml?: string;
   turningPoints?: { id: string; type: TurningPointType; summary: string }[];
   subplots?: Subplot[];
   scenes: Scene[]; 


### PR DESCRIPTION
## Summary
- type TipTap command props to avoid implicit `any` errors
- handle treatment markdown fields and update screenplay types
- remove unused imports and helpers across app

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ccfad0b888332a03b5475769e4acc