### PR TITLE
Move StoryDraft editor styles to external CSS

### DIFF
--- a/src/pages/StoryDraft/StoryDraftView.tsx
+++ b/src/pages/StoryDraft/StoryDraftView.tsx
@@ -27,6 +27,7 @@ import { useT } from '../../i18n';
 import FormattedDraft from '../../components/FormattedDraft';
 
 import type { Scene, Character } from '../../types';
+import '../../styles/sd-editor.css';
 
 /* ─────────────── Constantes / tipos ─────────────── */
 
@@ -485,47 +486,6 @@ function SceneEditorRow({
         </Typography>
       </Collapse>
 
-      {/* Estilos Hollywood */}
-      <style>{`
-        .sd-editor .ProseMirror {
-          outline: none;
-          min-height: 200px;
-          font-family: "Courier Prime", "Courier New", monospace;
-          font-size: 16px;         /* ~12pt */
-          line-height: 1.4;
-          letter-spacing: 0.01em;
-        }
-        .sd-editor .ProseMirror p {
-          margin: 0 0 8px 0;
-          white-space: pre-wrap;
-        }
-        .sd-editor .ProseMirror p[data-type="action"] {
-          margin-left: 0;
-          max-width: 65ch;
-        }
-        .sd-editor .ProseMirror p[data-type="character"] {
-          margin-left: 22ch;
-          max-width: 16ch;
-          text-transform: uppercase;
-          text-align: center;
-          font-weight: 700;
-          letter-spacing: 0.02em;
-        }
-        .sd-editor .ProseMirror p[data-type="parenthetical"] {
-          margin-left: 19ch;
-          max-width: 30ch;
-        }
-        .sd-editor .ProseMirror p[data-type="dialogue"] {
-          margin-left: 15ch;
-          max-width: 35ch;
-        }
-        .sd-editor .ProseMirror p[data-type="transition"] {
-          margin-left: auto;
-          max-width: 20ch;
-          text-align: right;
-          font-weight: 700;
-        }
-      `}</style>
     </Paper>
   );
 }

--- a/src/styles/sd-editor.css
+++ b/src/styles/sd-editor.css
@@ -1,0 +1,38 @@
+.sd-editor .ProseMirror {
+  outline: none;
+  min-height: 200px;
+  font-family: "Courier Prime", "Courier New", monospace;
+  font-size: 16px;         /* ~12pt */
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+}
+.sd-editor .ProseMirror p {
+  margin: 0 0 8px 0;
+  white-space: pre-wrap;
+}
+.sd-editor .ProseMirror p[data-type="action"] {
+  margin-left: 0;
+  max-width: 65ch;
+}
+.sd-editor .ProseMirror p[data-type="character"] {
+  margin-left: 22ch;
+  max-width: 16ch;
+  text-transform: uppercase;
+  text-align: center;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.sd-editor .ProseMirror p[data-type="parenthetical"] {
+  margin-left: 19ch;
+  max-width: 30ch;
+}
+.sd-editor .ProseMirror p[data-type="dialogue"] {
+  margin-left: 15ch;
+  max-width: 35ch;
+}
+.sd-editor .ProseMirror p[data-type="transition"] {
+  margin-left: auto;
+  max-width: 20ch;
+  text-align: right;
+  font-weight: 700;
+}


### PR DESCRIPTION
## Summary
- move StoryDraftView inline style rules into new sd-editor.css
- import stylesheet and remove inline <style> block

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cd42e52dc833296fa1eafa2a65023