### PR TITLE
feat: add author field to screenplay

### DIFF
--- a/src/pages/StoryMachine/StoryMachineShell.tsx
+++ b/src/pages/StoryMachine/StoryMachineShell.tsx
@@ -1,4 +1,4 @@
-import { Box, Paper, Typography, TextField } from '@mui/material';
+import { Box, Paper, TextField, Stack } from '@mui/material';
 import { Outlet } from 'react-router-dom';
 import { useEffect } from 'react';
 import { useProjects } from '../../state/projectStore';
@@ -6,18 +6,27 @@ import { useScreenplay } from '../../state/screenplayStore';
 
 export default function StoryMachineShell() {
   const { activeProjectId } = useProjects();
-  const { screenplay, load, setTitle } = useScreenplay();
+  const { screenplay, load, setTitle, setAuthor } = useScreenplay();
 
   useEffect(() => { if (activeProjectId) load(activeProjectId); }, [activeProjectId]);
 
   return (
     <Box>
       <Paper sx={{ p:2, mb:2 }}>
-        <Typography variant="h6">Proyecto: {screenplay?.title || 'Cargando...'}</Typography>
-        <TextField
-          label="Título del guion" value={screenplay?.title || ''}
-          onChange={(e)=>setTitle(e.target.value)} sx={{ mt:1, maxWidth: 420 }}
-        />
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="Título del guion"
+            value={screenplay?.title || ''}
+            onChange={(e) => setTitle(e.target.value)}
+            sx={{ flexGrow: 1 }}
+          />
+          <TextField
+            label="Autor"
+            value={screenplay?.author || ''}
+            onChange={(e) => setAuthor(e.target.value)}
+            sx={{ width: 250 }}
+          />
+        </Stack>
       </Paper>
 
       {/* Aquí se renderiza el editor de la sección activa (S1…S7) */}

--- a/src/pages/StoryMachine/StoryMachineView.tsx
+++ b/src/pages/StoryMachine/StoryMachineView.tsx
@@ -1,4 +1,4 @@
-import { Box, Paper, Tabs, Tab, Typography, TextField } from '@mui/material';
+import { Box, Paper, Tabs, Tab, TextField, Stack } from '@mui/material';
 import { useState, useEffect } from 'react';
 import { useProjects } from '../../state/projectStore';
 import { useScreenplay } from '../../state/screenplayStore';
@@ -16,7 +16,7 @@ const STEPS = ['S1 Sinopsis','S3 Puntos giro','S2 Tratamiento','S4 Personajes','
 export default function StoryMachineView() {
   const [tab, setTab] = useState(0);
   const { activeProjectId } = useProjects();
-  const { screenplay, load, setTitle } = useScreenplay();
+  const { screenplay, load, setTitle, setAuthor } = useScreenplay();
 
   useEffect(() => { if (activeProjectId) load(activeProjectId); }, [activeProjectId]);
 
@@ -29,11 +29,20 @@ export default function StoryMachineView() {
       </Paper>
 
       <Paper sx={{ p:2, mb:2 }}>
-        <Typography variant="h6">Proyecto: {screenplay?.title || 'Cargando...'}</Typography>
-        <TextField
-          label="Título del guion" value={screenplay?.title || ''}
-          onChange={(e)=>setTitle(e.target.value)} sx={{ mt:1, maxWidth: 420 }}
-        />
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="Título del guion"
+            value={screenplay?.title || ''}
+            onChange={(e) => setTitle(e.target.value)}
+            sx={{ flexGrow: 1 }}
+          />
+          <TextField
+            label="Autor"
+            value={screenplay?.author || ''}
+            onChange={(e) => setAuthor(e.target.value)}
+            sx={{ width: 250 }}
+          />
+        </Stack>
       </Paper>
 
       {/* Editores por paso */}

--- a/src/services/mockApi.ts
+++ b/src/services/mockApi.ts
@@ -50,8 +50,11 @@ export const mockScreenplays = {
     const all = read<any[]>(LS.screenplays, []);
     let s = all.find(x => x.projectId === projectId);
     if (!s) {
-      s = { id: uuid(), projectId, title: 'Nuevo Guion', scenes: [] };
+      s = { id: uuid(), projectId, title: 'Nuevo Guion', author: '', scenes: [] };
       all.push(s); write(LS.screenplays, all);
+    } else if (!('author' in s)) {
+      s.author = '';
+      write(LS.screenplays, all);
     }
     return s;
   },

--- a/src/state/screenplayStore.ts
+++ b/src/state/screenplayStore.ts
@@ -6,8 +6,9 @@ type SPState = {
   screenplay: Screenplay | null;
   load: (projectId: string) => Promise<void>;
   setTitle: (title: string) => void;
+  setAuthor: (author: string) => void;
   upsertScene: (scene: Partial<Scene>) => void;
-  patch: (partial: Partial<Screenplay>) => void; 
+  patch: (partial: Partial<Screenplay>) => void;
   setSynopsis: (synopsis: string) => void;
   setIdeationRows: (rows: IdeaRow[]) => void;
   setDecidedRow: (id: string | null) => void;
@@ -23,6 +24,10 @@ export const useScreenplay = create<SPState>((set, get) => ({
   },
   setTitle: (title) => {
     const sp = { ...get().screenplay!, title };
+    mockScreenplays.update(sp); set({ screenplay: sp });
+  },
+  setAuthor: (author) => {
+    const sp = { ...get().screenplay!, author };
     mockScreenplays.update(sp); set({ screenplay: sp });
   },
   upsertScene: (scene) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,8 +45,9 @@ export type IdeaRow = {
 };
 
 export type Screenplay = {
-  id: string; 
-  title: string; 
+  id: string;
+  title: string;
+  author?: string;
   projectId: string;
   synopsis?: string;
   treatment?: string;


### PR DESCRIPTION
## Summary
- remove intermediate project name in Story Machine pages
- allow editing screenplay author alongside title

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cd765f830833298f2859923136e98