### PR TITLE
feat: default screenplay title and author

### DIFF
--- a/src/pages/StoryMachine/StoryMachineShell.tsx
+++ b/src/pages/StoryMachine/StoryMachineShell.tsx
@@ -3,12 +3,19 @@ import { Outlet } from 'react-router-dom';
 import { useEffect } from 'react';
 import { useProjects } from '../../state/projectStore';
 import { useScreenplay } from '../../state/screenplayStore';
+import { useAuth } from '../../state/authStore';
 
 export default function StoryMachineShell() {
-  const { activeProjectId } = useProjects();
+  const { projects, activeProjectId } = useProjects();
+  const { user } = useAuth();
   const { screenplay, load, setTitle, setAuthor } = useScreenplay();
 
-  useEffect(() => { if (activeProjectId) load(activeProjectId); }, [activeProjectId]);
+  useEffect(() => {
+    if (activeProjectId) {
+      const project = projects.find(p => p.id === activeProjectId);
+      load(activeProjectId, { title: project?.name, author: user?.name });
+    }
+  }, [activeProjectId, projects, user?.name]);
 
   return (
     <Box>

--- a/src/services/mockApi.ts
+++ b/src/services/mockApi.ts
@@ -46,15 +46,26 @@ export const mockProjects = {
 };
 
 export const mockScreenplays = {
-  getOrCreateByProject: async (projectId: string) => {
+  getOrCreateByProject: async (
+    projectId: string,
+    defaults: { title?: string; author?: string } = {}
+  ) => {
     const all = read<any[]>(LS.screenplays, []);
     let s = all.find(x => x.projectId === projectId);
     if (!s) {
-      s = { id: uuid(), projectId, title: 'Nuevo Guion', author: '', scenes: [] };
+      s = {
+        id: uuid(),
+        projectId,
+        title: defaults.title ?? 'Nuevo Guion',
+        author: defaults.author ?? '',
+        scenes: [],
+      };
       all.push(s); write(LS.screenplays, all);
-    } else if (!('author' in s)) {
-      s.author = '';
-      write(LS.screenplays, all);
+    } else {
+      let changed = false;
+      if (!s.title) { s.title = defaults.title ?? 'Nuevo Guion'; changed = true; }
+      if (!s.author) { s.author = defaults.author ?? ''; changed = true; }
+      if (changed) write(LS.screenplays, all);
     }
     return s;
   },

--- a/src/state/screenplayStore.ts
+++ b/src/state/screenplayStore.ts
@@ -4,7 +4,7 @@ import type { Screenplay, Scene, IdeaRow } from '../types';
 
 type SPState = {
   screenplay: Screenplay | null;
-  load: (projectId: string) => Promise<void>;
+  load: (projectId: string, defaults?: { title?: string; author?: string }) => Promise<void>;
   setTitle: (title: string) => void;
   setAuthor: (author: string) => void;
   upsertScene: (scene: Partial<Scene>) => void;
@@ -16,8 +16,8 @@ type SPState = {
 
 export const useScreenplay = create<SPState>((set, get) => ({
   screenplay: null,
-  load: async (projectId) => {
-    const sp = await mockScreenplays.getOrCreateByProject(projectId);
+  load: async (projectId, defaults) => {
+    const sp = await mockScreenplays.getOrCreateByProject(projectId, defaults);
     // asegúrate de que haya estructura de ideation
     if (!sp.ideation) sp.ideation = { rows: [], decidedRowId: null };
     set({ screenplay: sp });


### PR DESCRIPTION
## Summary
- allow mock screenplay API to accept default title and author
- load default screenplay metadata from project and user in StoryMachine
- forward default values through screenplay store

## Testing
- `npm run typecheck`
- `npm run build` *(fails: The symbol "wrapText" has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_689d0539eb048332bdacde42818c185a