### PR TITLE
Add project status footer with screenplay metrics

### DIFF
--- a/src/components/ProjectStatusFooter.tsx
+++ b/src/components/ProjectStatusFooter.tsx
@@ -1,0 +1,52 @@
+import { Box, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import { useScreenplay } from '../state/screenplayStore';
+import { useT } from '../i18n';
+import { estimateDraftPages } from '../services/screenplayUtils';
+
+export default function ProjectStatusFooter() {
+  const { screenplay } = useScreenplay();
+  const t = useT();
+
+  const stats = useMemo(() => {
+    if (!screenplay) return null;
+    const prewritingDone = Boolean(
+      screenplay.ideation?.decidedRowId &&
+      (screenplay.turningPoints?.length || 0) > 0 &&
+      (screenplay.treatment || screenplay.treatmentHtml || screenplay.treatmentMd)
+    );
+
+    const scenes = screenplay.scenes || [];
+    const scriptedScenes = scenes.filter((s: any) => {
+      const blocks = s.scriptBlocks as any[] | undefined;
+      const hasBlocks = blocks && blocks.some(b => String(b.text || '').trim());
+      const hasHtml = typeof s.scriptHtml === 'string' && s.scriptHtml.trim();
+      return Boolean(hasBlocks || hasHtml);
+    }).length;
+
+    return {
+      prewritingDone,
+      characters: screenplay.characters?.length || 0,
+      locations: screenplay.locations?.length || 0,
+      totalScenes: scenes.length,
+      scriptedScenes,
+      pages: estimateDraftPages(screenplay)
+    };
+  }, [screenplay]);
+
+  if (!screenplay || !stats) return null;
+  const { prewritingDone, characters, locations, totalScenes, scriptedScenes, pages } = stats;
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-around', p: 1, borderTop: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
+      <Typography variant="caption">
+        {t('footer.prewriting')}: {t(prewritingDone ? 'footer.prewriting.completed' : 'footer.prewriting.pending')}
+      </Typography>
+      <Typography variant="caption">{t('footer.characters')}: {characters}</Typography>
+      <Typography variant="caption">{t('footer.locations')}: {locations}</Typography>
+      <Typography variant="caption">{t('footer.scenes')}: {totalScenes}</Typography>
+      <Typography variant="caption">{t('footer.scenesWithScript')}: {scriptedScenes}</Typography>
+      <Typography variant="caption">{t('footer.pages')}: {pages}</Typography>
+    </Box>
+  );
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -36,6 +36,16 @@ const dict: Record<Locale, Record<string, string>> = {
     // AppBar
     'project.none': 'Sin proyecto',
 
+    // Footer
+    'footer.prewriting': 'Preescritura',
+    'footer.prewriting.pending': 'Pendiente',
+    'footer.prewriting.completed': 'Completada',
+    'footer.characters': 'Personajes',
+    'footer.locations': 'Localizaciones',
+    'footer.scenes': 'Escenas',
+    'footer.scenesWithScript': 'Escenas con guion',
+    'footer.pages': 'Páginas',
+
     // ===== S1 — Ideación (Egri) =====
     's1.title': 'Ideación: Idea + Premisa + Tema + Género',
     's1.subtitle': 'Define hasta 5 ideas. Cada una lleva una Premisa (proposición causal de Egri), un Tema principal y un Género.',
@@ -358,6 +368,16 @@ const dict: Record<Locale, Record<string, string>> = {
     // AppBar
     'project.none': 'No project',
 
+    // Footer
+    'footer.prewriting': 'Prewriting',
+    'footer.prewriting.pending': 'Pending',
+    'footer.prewriting.completed': 'Completed',
+    'footer.characters': 'Characters',
+    'footer.locations': 'Locations',
+    'footer.scenes': 'Scenes',
+    'footer.scenesWithScript': 'Scripted scenes',
+    'footer.pages': 'Pages',
+
     // ===== S1 =====
     's1.title': 'Ideation: Idea + Premise + Theme + Genre',
     's1.subtitle': "Define up to 5 ideas. Each one has a Premise (Egri’s causal proposition), a main Theme and a Genre.",
@@ -671,6 +691,16 @@ const dict: Record<Locale, Record<string, string>> = {
 
     // AppBar
     'project.none': 'Sense projecte',
+
+    // Peu de pàgina
+    'footer.prewriting': 'Preescriptura',
+    'footer.prewriting.pending': 'Pendent',
+    'footer.prewriting.completed': 'Completada',
+    'footer.characters': 'Personatges',
+    'footer.locations': 'Localitzacions',
+    'footer.scenes': 'Escenes',
+    'footer.scenesWithScript': 'Escenes amb guió',
+    'footer.pages': 'Pàgines',
 
     // ===== S1 — Ideació (Egri) =====
     's1.title': 'Ideació: Idea + Premissa + Tema + Gènere',

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -7,6 +7,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LeftDrawer from '../components/LeftDrawer';
+import ProjectStatusFooter from '../components/ProjectStatusFooter';
 import { useProjects } from '../state/projectStore';
 import { useAuth } from '../state/authStore';
 import { useUi } from '../state/uiStore';
@@ -75,8 +76,11 @@ export default function AppLayout() {
 
       <LeftDrawer width={260} open={leftOpen} onClose={() => setLeftOpen(false)} />
 
-      <Box component="main" sx={{ flexGrow: 1, p: 2, mt: 8 }}>
+      <Box component="main" sx={{ flexGrow: 1, p: 2, mt: 8, pb: 8 }}>
         <Outlet />
+      </Box>
+      <Box component="footer" sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }}>
+        <ProjectStatusFooter />
       </Box>
     </Box>
   );

--- a/src/services/screenplayUtils.ts
+++ b/src/services/screenplayUtils.ts
@@ -1,0 +1,21 @@
+import type { Screenplay } from '../types';
+
+// Estimate draft pages based on 55 lines per page
+export function estimateDraftPages(screenplay: Screenplay): number {
+  const totalLines = (screenplay.scenes || []).reduce((sum, scene: any) => {
+    if (scene.scriptBlocks && Array.isArray(scene.scriptBlocks)) {
+      return (
+        sum + scene.scriptBlocks.reduce((acc: number, b: any) => acc + String(b.text || '').split(/\n/).filter(Boolean).length, 0)
+      );
+    }
+    if (scene.scriptHtml) {
+      const text = String(scene.scriptHtml)
+        .replace(/<[^>]+>/g, '\n')
+        .split(/\n/)
+        .filter((l) => l.trim()).length;
+      return sum + text;
+    }
+    return sum;
+  }, 0);
+  return Math.ceil(totalLines / 55);
+}


### PR DESCRIPTION
## Summary
- add ProjectStatusFooter component displaying screenplay stats
- estimate draft pages with new screenplayUtils helper
- translate footer labels for ES/EN/CA and integrate footer into AppLayout

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_689d053cf47c8332abefe05c9d2f1803